### PR TITLE
Fix input checked attr handling

### DIFF
--- a/client/hyalite/input_wrapper.rb
+++ b/client/hyalite/input_wrapper.rb
@@ -26,11 +26,16 @@ module Hyalite
     def native_props(inst)
       props = @dom_component.current_element.props
 
+      if props[:checked] || @wrapper_state[:initialChecked]
+        props = props.merge({
+          checked: props[:checked] || @wrapper_state[:initialChecked],
+        })
+      end
+
       props.merge({
         defaultChecked: nil,
         defaultValue: nil,
         value: props[:value] || @wrapper_state[:initialValue],
-        checked: props[:checked] || @wrapper_state[:initialChecked],
         onChange: @wrapper_state[:onChange],
       })
     end


### PR DESCRIPTION
In present input `checked` attr handling, `checked` attr always appears in rendered HTML, so some css framework can't work properly due to `checked` attr existence.

So, I'll let `checked` attr appear only when props[:checked] or @wrapper_state[:initialChecked] exists.

P.S. I am a ruby beginner, so my code may not be cool, sorry.